### PR TITLE
fix(client): consider case when createCard action is not among actions

### DIFF
--- a/app/clients/trello_client.rb
+++ b/app/clients/trello_client.rb
@@ -164,8 +164,10 @@ class TrelloClient
       trello_card.description = _json['desc']
 
       creation_action = _json['actions'].find { |a| a['type'] == 'createCard' }
-      trello_card.created_at = Time.parse creation_action['date']
-      trello_card.created_by_tid = creation_action['idMemberCreator']
+      trello_card.created_at =
+        creation_action.present? ? Time.parse(creation_action['date']) : nil
+      trello_card.created_by_tid =
+        creation_action.present? ? creation_action['idMemberCreator'] : nil
 
       if _properties.include? :movement
         move_action = _json['actions'].find { |a| a['type'] == 'updateCard' }


### PR DESCRIPTION
creation_action can be nil when the json does not list any createCard action. This happens when a card is very old and has a lot of actions after creation.